### PR TITLE
lambda_deploy_event fixes

### DIFF
--- a/bin/deployables
+++ b/bin/deployables
@@ -817,20 +817,19 @@ function lambda_deploy () {
 }
 
 function lambda_deploy_event () {
-
     lambda_event_basename="${1:-$DEPLOY_LAMBDA_EVENT_BASENAME}"
-
     if [[ -z "${lambda_event_basename}" ]] ; then
-        echo "Info: No DEPLOY_LAMBDA_EVENT_RULE, not deploying event."
+        echo "Error: DEPLOY_LAMBDA_EVENT_BASENAME or passing the basename is required for lambda_deploy_event."
+        return
+    fi
+
+    lambda_function_arn="${DEPLOY_LAMBDA_FUNCTION_ARN}"
+    if [[ -z "${lambda_function_arn}" ]] ; then
+        echo "Info: No DEPLOY_LAMBDA_FUNCTION_ARN, not deploying event."
         return
     fi
 
     if [[ -z "${DEPLOY_LAMBDA_EVENT_RULE}" ]] ; then
-        echo "Info: No DEPLOY_LAMBDA_EVENT_RULE, not deploying event."
-        return
-    fi
-
-    if [[ -z "${DEPLOY_LAMBDA_FUNCTION_ARN}" ]] ; then
         echo "Info: No DEPLOY_LAMBDA_EVENT_RULE, not deploying event."
         return
     fi
@@ -847,16 +846,6 @@ function lambda_deploy_event () {
 
     # this json is a sub-json to something else, so we need to escape the quotes for the awscli
     input_json_escaped=${DEPLOY_LAMBDA_TARGET_INPUT_JSON//\"/\\\"}
-
-    if [[ -z "${lambda_function_arn}" ]] ; then
-        echo "Error: DEPLOY_LAMBDA_FUNCTION_ARN or passing a 'lambda_function_arn' is required for lambda_deploy_event."
-        exit 1
-    fi
-
-    if [[ -z "${lambda_event_basename}" ]] ; then
-        echo "Error: DEPLOY_LAMBDA_EVENT_BASENAME or passing the basename is required for lambda_deploy_event."
-        exit 1
-    fi
 
     # create or update a cloudwatch event rule
     event_rule_arn=$( \


### PR DESCRIPTION
- fixes how `DEPLOY_LAMBDA_FUNCTION_ARN` is accepted
- improves error message when `DEPLOY_LAMBDA_EVENT_BASENAME` is missing